### PR TITLE
KH DDD PS4/PC fixes

### DIFF
--- a/KHSave.Archives/Factories/Ps4KhDddFactory.cs
+++ b/KHSave.Archives/Factories/Ps4KhDddFactory.cs
@@ -23,7 +23,7 @@ namespace KHSave.Archives.Factories
     public class Ps4KhDddFactory : IArchiveFactory
     {
         private const int EntryCount = 100;
-        private const int Stride = 0x2cc00;
+        private const int Stride = 0x16600;
         private const int Size = 0x8bfc00;
 
         public string Name => "PS4 KHDDD";

--- a/KHSave.Lib2/SaveKh2.cs
+++ b/KHSave.Lib2/SaveKh2.cs
@@ -88,7 +88,9 @@ namespace KHSave.Lib2
             {
                 save.Write(tempStream);
                 var rawData = tempStream.SetPosition(0xc).ReadBytes();
+                // Calculate checksum of Magiccode and Version.
                 checksum = CalculateChecksum(tempStream.FromBegin().ReadBytes(8), 8, uint.MaxValue);
+                // Calculate checksum of the rest of the gamedata.
                 checksum = CalculateChecksum(rawData, rawData.Length, checksum ^ uint.MaxValue);
             }
 

--- a/KHSave.LibDDD/ISaveKhDDD.cs
+++ b/KHSave.LibDDD/ISaveKhDDD.cs
@@ -20,8 +20,8 @@ namespace KHSave.LibDDD
         EquipmentType SoraKeyblade { get; set; }
         EquipmentType RikuKeyblade { get; set; }
         UInt32 Munny { get; set; }
-        Deck[] SoraDecks { get; set; }
-        Deck[] RikuDecks { get; set; }
+        IDeck[] SoraDecks { get; }
+        IDeck[] RikuDecks { get; }
 
         void Write(Stream stream);
     }

--- a/KHSave.LibDDD/ISaveKhDDD.cs
+++ b/KHSave.LibDDD/ISaveKhDDD.cs
@@ -7,15 +7,21 @@ namespace KHSave.LibDDD
 {
     public interface ISaveKhDDD
     {
+        uint GameTimeLoading { get; set; }
+        DifficultyType DifficultyLoading { get; set; }
+        uint SoraXpLoading { get; set; }
         DifficultyType Difficulty { get; set; }
         WorldType WorldId { get; set; }
         byte RoomId { get; set; }
         byte SpawnId { get; set; }
+        uint GameTime { get; set; }
         DreamEater[] DreamEaters { get; set; }
         CommandEntry[] CommandInventory { get; }
         UInt32 SoraXp { get; set; }
+        ushort SoraDroplets { get; set; }
         byte SoraLv { get; set; }
         UInt32 RikuXp { get; set; }
+        ushort RikuDroplets { get; set; }
         byte RikuLv { get; set; }
         EquipmentType SoraKeyblade { get; set; }
         EquipmentType RikuKeyblade { get; set; }

--- a/KHSave.LibDDD/Model/Deck.cs
+++ b/KHSave.LibDDD/Model/Deck.cs
@@ -2,7 +2,7 @@ using Xe.BinaryMapper;
 
 namespace KHSave.LibDDD.Model
 {
-    public class Deck
+    public class Deck : IDeck
     {
         [Data(Count = 220)] public byte[] Unk01 { get; set; }
         [Data(Count = 16)] public byte[] Name { get; set; }

--- a/KHSave.LibDDD/Model/DeckPS4.cs
+++ b/KHSave.LibDDD/Model/DeckPS4.cs
@@ -1,0 +1,11 @@
+using Xe.BinaryMapper;
+
+namespace KHSave.LibDDD.Model
+{
+    public class DeckPS4 : IDeck
+    {
+        [Data(Count = 220)] public byte[] Unk01 { get; set; }
+        [Data(Count = 43)] public byte[] Name { get; set; }
+        [Data(Count = 55)] public byte[] Unk02 { get; set; }
+    }
+}

--- a/KHSave.LibDDD/Model/IDeck.cs
+++ b/KHSave.LibDDD/Model/IDeck.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KHSave.LibDDD.Model
+{
+    public interface IDeck
+    {
+        public byte[] Unk01 { get; set; }
+        public byte[] Name { get; set; }
+        public byte[] Unk02 { get; set; }
+    }
+}

--- a/KHSave.LibDDD/SaveKhDDD.3DS.cs
+++ b/KHSave.LibDDD/SaveKhDDD.3DS.cs
@@ -31,7 +31,7 @@ namespace KHSave.LibDDD
             [Data(0xd1cc)] public uint SoraXp { get; set; }
             [Data(0xd1e0)] public ushort SoraDroplets { get; set; }
             [Data(0xd1f0)] public byte SoraLv { get; set; }
-            
+
             //RikuXp max value 786680?
             [Data(0xd248)] public uint RikuXp { get; set; }
             [Data(0xd25c)] public ushort RikuDroplets { get; set; }

--- a/KHSave.LibDDD/SaveKhDDD.3DS.cs
+++ b/KHSave.LibDDD/SaveKhDDD.3DS.cs
@@ -14,10 +14,14 @@ namespace KHSave.LibDDD
         public class SaveKhDDD3DS : ISaveKhDDD
         {
             [Data(0, 0x163FF)] public byte[] Data { get; set; }
-            [Data(0x20)] public DifficultyType Difficulty { get; set; }
+            [Data(0x10)] public uint GameTimeLoading { get; set; }
+            [Data(0x20)] public DifficultyType DifficultyLoading { get; set; }
+            [Data(0x28)] public uint SoraXpLoading { get; set; }
+            [Data(0x92)] public DifficultyType Difficulty { get; set; }
             [Data(0x94)] public WorldType WorldId { get; set; }
             [Data] public byte RoomId { get; set; }
             [Data] public byte SpawnId { get; set; }
+            [Data(0x98)] public uint GameTime { get; set; }
             //3 in party and 99 on the bank
             [Data(0x53a0, Count = 102)] public DreamEater[] DreamEaters { get; set; }
 
@@ -25,9 +29,12 @@ namespace KHSave.LibDDD
 
             //SoraXp max value 786680?
             [Data(0xd1cc)] public uint SoraXp { get; set; }
+            [Data(0xd1e0)] public ushort SoraDroplets { get; set; }
             [Data(0xd1f0)] public byte SoraLv { get; set; }
+            
             //RikuXp max value 786680?
             [Data(0xd248)] public uint RikuXp { get; set; }
+            [Data(0xd25c)] public ushort RikuDroplets { get; set; }
             [Data(0xd26c)] public byte RikuLv { get; set; }
             [Data(0xd2c4)] public EquipmentType SoraKeyblade { get; set; }
             [Data(0xd2c6)] public EquipmentType RikuKeyblade { get; set; }

--- a/KHSave.LibDDD/SaveKhDDD.3DS.cs
+++ b/KHSave.LibDDD/SaveKhDDD.3DS.cs
@@ -36,6 +36,9 @@ namespace KHSave.LibDDD
             [Data(0xd2f0, Count = 3)] public Deck[] SoraDecks { get; set; }
             [Data(0xd5fc, Count = 3)] public Deck[] RikuDecks { get; set; }
 
+            IDeck[] ISaveKhDDD.SoraDecks => Array.ConvertAll(SoraDecks, x => (IDeck)x);
+            IDeck[] ISaveKhDDD.RikuDecks => Array.ConvertAll(SoraDecks, x => (IDeck)x);
+
             public void Write(Stream stream) =>
                 BinaryMapping.WriteObject(stream.FromBegin(), this);
         }

--- a/KHSave.LibDDD/SaveKhDDD.PS4.cs
+++ b/KHSave.LibDDD/SaveKhDDD.PS4.cs
@@ -30,8 +30,11 @@ namespace KHSave.LibDDD
             [Data(0xd2ea)] public EquipmentType RikuKeyblade { get; set; }
             //Munny max value 999999?
             [Data(0xd2ec)] public uint Munny { get; set; }
-            [Data(0xd314, Count = 3)] public Deck[] SoraDecks { get; set; }
-            [Data(0xd620, Count = 3)] public Deck[] RikuDecks { get; set; }
+            [Data(0xd314, Count = 3)] public DeckPS4[] SoraDecks { get; set; }
+            [Data(0xd620, Count = 3)] public DeckPS4[] RikuDecks { get; set; }
+
+            IDeck[] ISaveKhDDD.SoraDecks => Array.ConvertAll(SoraDecks, x => (IDeck)x);
+            IDeck[] ISaveKhDDD.RikuDecks => Array.ConvertAll(SoraDecks, x => (IDeck)x);
 
             public void Write(Stream stream) =>
                 BinaryMapping.WriteObject(stream.FromBegin(), this);

--- a/KHSave.LibDDD/SaveKhDDD.PS4.cs
+++ b/KHSave.LibDDD/SaveKhDDD.PS4.cs
@@ -11,10 +11,14 @@ namespace KHSave.LibDDD
         public class SaveKhDDDPS4 : ISaveKhDDD
         {
             [Data(0, 0x165FF)] public byte[] Data { get; set; }
-            [Data(0x20)] public DifficultyType Difficulty { get; set; }
+            [Data(0x10)] public uint GameTimeLoading { get; set; }
+            [Data(0x20)] public DifficultyType DifficultyLoading { get; set; }
+            [Data(0x28)] public uint SoraXpLoading { get; set; }
+            [Data(0x92)] public DifficultyType Difficulty { get; set; }
             [Data(0x94)] public WorldType WorldId { get; set; }
             [Data] public byte RoomId { get; set; }
             [Data] public byte SpawnId { get; set; }
+            [Data(0x98)] public uint GameTime { get; set; }
             //3 in party and 99 on the bank
             [Data(0x53a0, Count = 102)] public DreamEater[] DreamEaters { get; set; }
 
@@ -22,9 +26,11 @@ namespace KHSave.LibDDD
 
             //SoraXp max value 786680?
             [Data(0xd1f0)] public uint SoraXp { get; set; }
+            [Data(0xd204)] public ushort SoraDroplets { get; set; }
             [Data(0xd214)] public byte SoraLv { get; set; }
             //RikuXp max value 786680?
             [Data(0xd26c)] public uint RikuXp { get; set; }
+            [Data(0xd280)] public ushort RikuDroplets { get; set; }
             [Data(0xd290)] public byte RikuLv { get; set; }
             [Data(0xd2e8)] public EquipmentType SoraKeyblade { get; set; }
             [Data(0xd2ea)] public EquipmentType RikuKeyblade { get; set; }

--- a/KHSave.SaveEditor.KhDDD/ViewModels/DeckViewModel.cs
+++ b/KHSave.SaveEditor.KhDDD/ViewModels/DeckViewModel.cs
@@ -6,9 +6,9 @@ namespace KHSave.SaveEditor.KhDDD.ViewModels
 {
     public class DeckViewModel : BaseNotifyPropertyChanged
     {
-        private readonly Deck deck;
+        private readonly IDeck deck;
 
-        public DeckViewModel(Deck deck)
+        public DeckViewModel(IDeck deck)
         {
             this.deck = deck;
         }

--- a/KHSave.SaveEditor.KhDDD/ViewModels/DecksViewModel.cs
+++ b/KHSave.SaveEditor.KhDDD/ViewModels/DecksViewModel.cs
@@ -6,7 +6,7 @@ namespace KHSave.SaveEditor.KhDDD.ViewModels
 {
     public class DecksViewModel : GenericListModel<DeckViewModel>
     {
-        public DecksViewModel(Deck[] decks) :
+        public DecksViewModel(IDeck[] decks) :
             base(decks.Select(x => new DeckViewModel(x)))
         { }
     }

--- a/KHSave.SaveEditor.KhDDD/ViewModels/SystemViewModel.cs
+++ b/KHSave.SaveEditor.KhDDD/ViewModels/SystemViewModel.cs
@@ -12,7 +12,7 @@ namespace KHSave.SaveEditor.KhDDD.ViewModels
         public SystemViewModel(ISaveKhDDD save)
         {
             this.save = save;
-            Difficulty = new KhEnumListModel<DifficultyType>(() => save.Difficulty, x => save.Difficulty = x);
+            Difficulty = new KhEnumListModel<DifficultyType>(() => save.DifficultyLoading, x => save.DifficultyLoading = x);
             Worlds = new KhEnumListModel<WorldType>();
         }
 

--- a/KHSave.SaveEditor.KhDDD/ViewModels/SystemViewModel.cs
+++ b/KHSave.SaveEditor.KhDDD/ViewModels/SystemViewModel.cs
@@ -12,7 +12,7 @@ namespace KHSave.SaveEditor.KhDDD.ViewModels
         public SystemViewModel(ISaveKhDDD save)
         {
             this.save = save;
-            Difficulty = new KhEnumListModel<DifficultyType>(() => save.DifficultyLoading, x => save.DifficultyLoading = x);
+            Difficulty = new KhEnumListModel<DifficultyType>(() => save.Difficulty, x => save.Difficulty = x);
             Worlds = new KhEnumListModel<WorldType>();
         }
 


### PR DESCRIPTION
Fixes ps4/pc save data differences.
Added a few values to the the lib for both versions but they're not exposed to the UI yet.
Added random comment to the kh2 hash function to understand it better.
Fixed stride offset for ps4 saves as the value was wrong.